### PR TITLE
Don't send accelerometer and plunger axis updates when the values remain the same

### DIFF
--- a/Accelerometer.cpp
+++ b/Accelerometer.cpp
@@ -165,8 +165,15 @@ void Accelerometer::accelerometerRead()
     buttonState = 0;
   }
 
-  _joystick->setXAxis(xValue);
-  _joystick->setYAxis(yValue);
+  if (priorXValue != xValue) {
+    _joystick->setXAxis(xValue);
+    priorXValue = xValue;
+  }
+
+  if (priorYValue != yValue) {
+    _joystick->setYAxis(yValue);
+    priorYValue = yValue;
+  }
 
   // Serial.print(F("DEBUG,AccelX:"));
   // Serial.print(xValue);

--- a/Accelerometer.h
+++ b/Accelerometer.h
@@ -23,8 +23,8 @@ class Accelerometer {
     Joystick_* _joystick;
     int xValue;
     int yValue;
-    int priorXValue;
-    int priorYValue;
+    int priorXValue = 0;
+    int priorYValue = 0;
     byte buttonState;
     bool recentered = false;
     byte orientation = 0;

--- a/Plunger.cpp
+++ b/Plunger.cpp
@@ -69,7 +69,10 @@ void Plunger::plungerRead() {
     adjustedValue = (sensorValue-_config->plungerMid) * plungerScaleFactor + _config->plungerMid;
   }
   //if (DEBUG) {Serial.print(F("DEBUG,plunger: scale factor ")); Serial.print(plungerScaleFactor); Serial.print(F("DEBUG,plunger: value ")); Serial.print(adjustedValue); Serial.print("\r\n");}
-  _joystick->setZAxis(adjustedValue);
+  if (priorValue != adjustedValue) {
+    _joystick->setZAxis(adjustedValue);
+    priorValue = adjustedValue;
+  }
 }
 
 void Plunger::sendPlungerState() {

--- a/Plunger.h
+++ b/Plunger.h
@@ -21,7 +21,7 @@ class Plunger {
     Config* _config;
     byte buttonState;
     byte buttonState2;
-    int priorValue;
+    int priorValue = 0;
 };
 
 #endif


### PR DESCRIPTION
I tested it and there is no change in behavior. This should reduce the load on USB/system as there is no point in sending the same axis values again and again for joystick devices. This is actually recommended and used in the Joystick library samples.